### PR TITLE
Add ShellyProEM3 support

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -92,7 +92,7 @@ zero_offset = 20
 [shellyproem3]
 # The MQTT base topic your Shelly 3EM (Pro) is posting it's telemetry data to
 # Note: you have to configure your Shelly to use MQTT set prefix to the same value as the base topic here
-base_topic = shellypro3em
+base_topic = shellyproem3
 rapid_change_diff = 500
 zero_offset = 20
 

--- a/src/config.ini
+++ b/src/config.ini
@@ -89,6 +89,13 @@ base_topic = shellies/shellyem3/
 rapid_change_diff = 500
 zero_offset = 20
 
+[shellyproem3]
+# The MQTT base topic your Shelly 3EM (Pro) is posting it's telemetry data to
+# Note: you have to configure your Shelly to use MQTT set prefix to the same value as the base topic here
+base_topic = shellypro3em
+rapid_change_diff = 500
+zero_offset = 20
+
 [control]
 min_charge_power = 125
 max_discharge_power = 150

--- a/src/solarflow/smartmeters.py
+++ b/src/solarflow/smartmeters.py
@@ -183,7 +183,7 @@ class ShellyProEM3(Smartmeter):
         self.rapid_change_diff = rapid_change_diff
         self.zero_offset = zero_offset
         self.last_trigger_value = 0
-        self.total_act_power = 0
+        self.total_act_power = None
         self.trigger_callback = callback
         log.info(f'Using {type(self).__name__}: Base topic: {self.base_topic}')
 
@@ -200,7 +200,7 @@ class ShellyProEM3(Smartmeter):
             log.info(f'ShellyPro3EM subscribing: {t}')
 
     def ready(self):
-        return len(self.total_act_power) > 0
+        return self.total_act_power is not None
 
     def updPower(self):
         force_trigger = False

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -254,6 +254,7 @@ def getSFPowerLimit(hub, demand) -> int:
         if hub.control_bypass:
             hub.allowBypass(True)
             hub.setBypass(False)
+            hub.setAutorecover(False)
 
     log.info(f'Based on time, solarpower ({hub_solarpower:4.1f}W) minimum charge power ({MIN_CHARGE_POWER}W) and bypass state ({hub.getBypass()}), hub could contribute {limit:4.1f}W - Decision path: {path}')
     return int(limit)


### PR DESCRIPTION
First of all, thank you for this project!

Today I tried to swtich my SF-HUB to local control but ended up having issues. I was wondering why SF-control wouldn't get any data from my shelly. Turns out there is a difference between the pro and none pro version. The pro version frequently (on every change in values with a check every second or so) reports its data to the topic:
<configured_prefix>/status/em:0

The payload is a json which looks (for example) like this:
`
{
    "id": 0,
    "a_current": 0.382,
    "a_voltage": 233.1,
    "a_act_power": 33.2,
    "a_aprt_power": 89.2,
    "a_pf": 0.68,
    "a_freq": 50,
    "b_current": 9.508,
    "b_voltage": 229.2,
    "b_act_power": 2153.3,
    "b_aprt_power": 2172.4,
    "b_pf": 0.99,
    "b_freq": 50,
    "c_current": 0.288,
    "c_voltage": 234.6,
    "c_act_power": 52.2,
    "c_aprt_power": 67.5,
    "c_pf": 0.77,
    "c_freq": 50,
    "n_current": null,
    "total_current": 10.179,
    "total_act_power": 2238.718,
    "total_aprt_power": 2329.089,
    "user_calibrated_phase": []
}`

This gives us information about the status of the different phases as well as total values. "total_act_power" represents the sum of the power of all 3 phases.

I added the necessary definitions and and variables to make use of this value from a shellyproem3 that promotes its data via MQTT.

I hope this helps. Some of the code could probably be adapted to allow for reuse of the definitions instead of having them copy pasted multiple times.

I am not a programar but I hope this helps :)