### PR TITLE
Make hub's SoC levels configurable

### DIFF
--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -261,8 +261,12 @@ def getSFPowerLimit(hub, demand) -> int:
             hub.setBypass(False)
             hub.setAutorecover(False)
             
-        # check if we should run a full charge cycle
-        hub.checkChargeThrough()
+        # calculate expected daylight in hours
+        diff = sunset - sunrise
+        daylight = diff.total_seconds()/3600
+
+        # check if we should run a full charge cycle today
+        hub.checkChargeThrough(daylight)
 
     log.info(f'Based on time, solarpower ({hub_solarpower:4.1f}W) minimum charge power ({MIN_CHARGE_POWER}W) and bypass state ({hub.getBypass()}), hub could contribute {limit:4.1f}W - Decision path: {path}')
     return int(limit)

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -69,9 +69,9 @@ MAX_DISCHARGE_POWER =   config.getint('control', 'max_discharge_power', fallback
 
 # battery SoC levels to consider the battery full or empty
 BATTERY_LOW =           config.getint('control', 'battery_low', fallback=None) \
-                        or int(os.environ.get('BATTERY_LOW',10)) 
+                        or int(os.environ.get('BATTERY_LOW',0)) 
 BATTERY_HIGH =          config.getint('control', 'battery_high', fallback=None) \
-                        or int(os.environ.get('BATTERY_HIGH',98))
+                        or int(os.environ.get('BATTERY_HIGH',100))
 
 # the maximum allowed inverter output
 MAX_INVERTER_LIMIT =    config.getint('control', 'max_inverter_limit', fallback=None) \

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -144,6 +144,8 @@ def on_connect(client, userdata, flags, rc):
         hub = client._userdata['hub']
         hub.subscribe()
         hub.setBuzzer(False)
+        hub.setBatteryHighSoC(BATTERY_HIGH)
+        hub.setBatteryLowSoC(BATTERY_LOW)
         if hub.control_bypass:
             hub.setBypass(False)
             hub.setAutorecover(False)

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -67,7 +67,7 @@ class Solarflow:
 
         self.property_topic = f'iot/{self.productId}/{self.deviceId}/properties/write'
         self.chargeThrough = False
-        self.chargeThroughStage = 'idle'
+        self.chargeThroughStage = BATTERY_TARGET_IDLE
         self.dryrun = False
         self.sunriseSoC = None
         self.sunsetSoC = None
@@ -197,7 +197,7 @@ class Solarflow:
                 log.info(f'Battery is empty: {self.electricLevel} => {value}')
             
             if self.chargeThrough:
-                self.setChargeThroughStage(BATTERY_TARGET_IDLE)
+                self.setChargeThrough(False)
 
             self.lastEmptyTS = datetime.now()
             self.client.publish(f'solarflow-hub/{self.deviceId}/control/lastEmptyTimestamp',int(datetime.timestamp(self.lastEmptyTS)),retain=True)

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -64,7 +64,7 @@ class Solarflow:
         self.control_soc = control_soc    # wether we control the soc levels
 
         self.property_topic = f'iot/{self.productId}/{self.deviceId}/properties/write'
-        self.chargeThrough = True
+        self.chargeThrough = False
         self.dryrun = False
         self.sunriseSoC = None
         self.sunsetSoC = None

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -18,6 +18,7 @@ TRIGGER_DIFF = 30
 HUB1200 = "73bkTV"
 HUB2000 = "A8yh63"
 
+BATTERY_TARGET_IDLE        = "idle"
 BATTERY_TARGET_CHARGING    = "charging"
 BATTERY_TARGET_DISCHARGING = "discharging"
 
@@ -26,12 +27,12 @@ INVERTER_BRAND = {0: 'Other', 1: 'Hoymiles', 2: 'Enphase', 3: 'APsystems', 4: 'A
 
 
 class Solarflow:
-    opts = {"product_id":str, "device_id":str ,"full_charge_interval":int, "control_bypass":bool, "control_soc":bool}
+    opts = {"product_id":str, "device_id":str ,"full_charge_interval":int, "control_bypass":bool, "control_soc":bool, "disable_full_discharge":bool}
 
     def default_calllback(self):
         log.info("default callback")
 
-    def __init__(self, client: mqtt_client, product_id:str, device_id:str, full_charge_interval:int, control_bypass:bool = False, control_soc:bool = False, callback = default_calllback):
+    def __init__(self, client: mqtt_client, product_id:str, device_id:str, full_charge_interval:int, control_bypass:bool = False, control_soc:bool = False, disable_full_discharge:bool = False, callback = default_calllback):
         self.client = client
         self.productId = product_id
         self.deviceId = device_id
@@ -56,6 +57,7 @@ class Solarflow:
         self.lastEmptyTS = None         # keep track of last time the battery pack was empty (0%)
         self.lastSolarInputTS = None    # time of the last received solar input value
         self.batteryTarget = None
+        self.allowFullCycle = not disable_full_discharge
         
         self.batteryTargetSoCMax = -1
         self.batteryTargetSoCMin = -1
@@ -65,6 +67,7 @@ class Solarflow:
 
         self.property_topic = f'iot/{self.productId}/{self.deviceId}/properties/write'
         self.chargeThrough = False
+        self.chargeThroughStage = 'idle'
         self.dryrun = False
         self.sunriseSoC = None
         self.sunsetSoC = None
@@ -177,7 +180,13 @@ class Solarflow:
                 log.info(f'Battery is full: {self.electricLevel}')
 
             if self.chargeThrough:
-                self.setChargeThrough(False)
+                # if allowed to run full cycle, change to discharge,now
+                if self.allowFullCycle:
+                    self.setChargeThroughStage(BATTERY_TARGET_DISCHARGING)
+                # otherwise, we are done
+                else:
+                    self.setChargeThrough(False)
+                    
             
             self.lastFullTS = datetime.now()
             self.client.publish(f'solarflow-hub/{self.deviceId}/control/lastFullTimestamp',int(datetime.timestamp(self.lastFullTS)),retain=True)
@@ -188,12 +197,15 @@ class Solarflow:
                 log.info(f'Battery is empty: {self.electricLevel}')
 
             batteryTarget = BATTERY_TARGET_CHARGING
+            
+            if self.chargeThrough:
+                self.setChargeThroughStage(BATTERY_TARGET_IDLE)
 
             self.lastEmptyTS = datetime.now()
             self.client.publish(f'solarflow-hub/{self.deviceId}/control/lastEmptyTimestamp',int(datetime.timestamp(self.lastEmptyTS)),retain=True)
 
         # handle user given min SoC
-        if value <= self.batteryLow:
+        if value <= self.batteryLow and not self.chargeThrough:
             batteryTarget = BATTERY_TARGET_CHARGING
 
             if self.batteryTarget == BATTERY_TARGET_DISCHARGING:
@@ -286,11 +298,6 @@ class Solarflow:
             log.info(f'Impossible to set charge through! We are not permitted to change maximum target SoC and solarflow has limit configured to {self.batteryTargetSoCMax}!')
             return
         
-        log.info(f'Set ChargeThrough: {chargeThrough}')
-
-        # adjust charge limit
-        self.setBatteryHighSoC(100 if chargeThrough else self.batteryHigh, True)
-
         # in case of setups with no direct panels connected to inverter it is necessary to turn on the inverter as it is likely offline now
         inv = self.client._userdata['dtu']
         if (not inv.ready()) and self.getOutputHomePower() == 0:
@@ -298,10 +305,22 @@ class Solarflow:
             self.setOutputLimit(30)
 
         if self.chargeThrough != chargeThrough:
+            log.info(f'Set ChargeThrough: {self.chargeThrough} => {chargeThrough}')
+            self.setChargeThroughStage(BATTERY_TARGET_CHARGING if chargeThrough else BATTERY_TARGET_IDLE)
             self.client.publish(f'solarflow-hub/{self.deviceId}/control/chargeThrough','ON' if chargeThrough else 'OFF')
+            
 
         self.chargeThrough = chargeThrough
 
+    def setChargeThroughStage(self,stage):
+        log.info(f'Updateing charge through stage: {self.chargeThroughStage} => {stage}')
+        batteryHigh = 100 if stage in [BATTERY_TARGET_CHARGING, BATTERY_TARGET_DISCHARGING] else self.batteryHigh
+        batteryLow = 0 if stage == BATTERY_TARGET_DISCHARGING and self.allowFullCycle else 0
+        self.client.publish(f'solarflow-hub/{self.deviceId}/control/chargeThroughState', stage)
+        self.setBatteryHighSoC(batteryHigh)
+        self.setBatteryLowSoC(batteryLow)
+        self.chargeThroughStage = stage
+        
     def setDryRun(self,value):
         if type(value) == str:
             self.dryrun = value.upper() == 'ON'
@@ -405,6 +424,8 @@ class Solarflow:
                     self.updBatteryTargetSoCMax(int(value))
                 case "minSoc":
                     self.updBatteryTargetSoCMin(int(value))
+                case "chargeThroughState":
+                    pass
                 case _:
                     log.warning(f'Ignoring solarflow-hub metric: {metric}')
 

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -170,7 +170,7 @@ class Solarflow:
             batteryTarget = BATTERY_TARGET_DISCHARGING
 
             if self.batteryTarget == BATTERY_TARGET_CHARGING:
-                log.info(f'Battery is full: {self.electricLevel}')
+                log.info(f'Battery is full: {self.electricLevel} => {value}')
 
             if self.chargeThrough:
                 # if allowed to run full cycle, change to discharge,now
@@ -187,14 +187,14 @@ class Solarflow:
             batteryTarget = BATTERY_TARGET_DISCHARGING
 
             if self.batteryTarget == BATTERY_TARGET_CHARGING:
-                log.info(f'Battery maximum charge level reached: {self.electricLevel}')
+                log.info(f'Battery maximum charge level reached: {self.electricLevel} => {value}')
                 
         # handle empty battery
         if value == 0:
             batteryTarget = BATTERY_TARGET_CHARGING
             
             if self.batteryTarget == BATTERY_TARGET_DISCHARGING:
-                log.info(f'Battery is empty: {self.electricLevel}')
+                log.info(f'Battery is empty: {self.electricLevel} => {value}')
             
             if self.chargeThrough:
                 self.setChargeThroughStage(BATTERY_TARGET_IDLE)
@@ -206,7 +206,7 @@ class Solarflow:
             batteryTarget = BATTERY_TARGET_CHARGING
 
             if self.batteryTarget == BATTERY_TARGET_DISCHARGING:
-                log.info(f'Battery minimum charge level reached: {self.electricLevel}')
+                log.info(f'Battery minimum charge level reached: {self.electricLevel} => {value}')
 
         # process changes
         if batteryTarget != self.batteryTarget:
@@ -310,12 +310,15 @@ class Solarflow:
         self.chargeThrough = chargeThrough
 
     def setChargeThroughStage(self,stage):
+        if self.chargeThroughStage == stage:
+            return
+        
         log.info(f'Updateing charge through stage: {self.chargeThroughStage} => {stage}')
         batteryHigh = 100 if stage in [BATTERY_TARGET_CHARGING, BATTERY_TARGET_DISCHARGING] else self.batteryHigh
-        batteryLow = 0 if stage == BATTERY_TARGET_DISCHARGING and self.allowFullCycle else 0
+        batteryLow = 0 if stage == BATTERY_TARGET_DISCHARGING and self.allowFullCycle else self.batteryLow
         self.client.publish(f'solarflow-hub/{self.deviceId}/control/chargeThroughState', stage)
-        self.setBatteryHighSoC(batteryHigh)
-        self.setBatteryLowSoC(batteryLow)
+        self.setBatteryHighSoC(batteryHigh, True)
+        self.setBatteryLowSoC(batteryLow, True)
         self.chargeThroughStage = stage
         
     def setDryRun(self,value):

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -528,35 +528,36 @@ class Solarflow:
     def setBatteryHighSoC(self, level:int, temporary:bool=False) -> int:
         level = min(max(level, 40), 100)
         if not temporary:
-            log.info(f'Setting maximum charge level to {level}%')
             self.batteryHigh = level
-        
+
         if not self.control_soc:
             return self.batteryLow
-        
+
         payload = {"properties": { "socSet": level * 10 }}
         self.client.publish(self.property_topic,json.dumps(payload))
+        log.info(f'Setting maximum charge level to {level}%')
         return level
 
     def setBatteryLowSoC(self, level:int, temporary:bool=False) -> int:
         level = min(max(level, 0), 60)
         if not temporary:
-            log.info(f'Setting minimum charge level to {level}%')
             self.batteryLow = level
-            
+
         if not self.control_soc:
             return self.batteryLow
-        
+
         payload = {"properties": { "minSoc": level * 10 }}
         self.client.publish(self.property_topic,json.dumps(payload))
+        log.info(f'Setting minimum charge level to {level}%')
         return level
-    
-    def checkChargeThrough(self, daylight:int = 0) -> bool:
+
+    def checkChargeThrough(self, daylight:float = 0.0) -> bool:
+        log.info(f'Checking conditions for charge through with expexted daylight of {daylight:.1f} hours')
         fullage = self.getLastFullBattery()
         fullage_today = fullage + daylight
         # check if we should enable charge through
         if fullage < 0 or fullage > self.fullChargeInterval or fullage_today > self.fullChargeInterval:
-            log.info(f'Battery hasn\'t fully charged for {fullage:.1f} hours! To ensure it is fully charged at least every {self.fullChargeInterval}hrs chargeing through now!')
+            log.info(f'Battery hasn\'t fully charged for {fullage:.1f} hours! To ensure it is fully charged at least every {self.fullChargeInterval} hours chargeing through now!')
             self.setChargeThrough(True) 
             
         return self.chargeThrough

--- a/src/solarflow/utils.py
+++ b/src/solarflow/utils.py
@@ -120,7 +120,7 @@ def deep_get(dictionary, keys, default=None):
     return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
 
 def str2bool (val):
-    val = val.lower()
+    val = str(val).lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):
         return True
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):


### PR DESCRIPTION
This PR implements usage of BATTERY_LOW and BATTERY_HIGH to be written to hub (if enabled by `control_soc` parameter) and when configured to handle BYPASS manually. Charge-Trough mode is updated accordingly to work with these changes - this also fixes an issue, where BYPASS is never turned on in manual mode when hub is configured to a maximum charge level below 100%.
Checking for Charge-Trough is updated to run only on sunrise and is also checking if battery will reach threshold within daytime. Additionally, MAX_INVERTER_INPUT can now be explicitly set via env or parameter (defaults to old behavior if not explicitly specified) and is written to hub. Hub's inverter configuration has been added and is currently forced to 'Hoymiles' on startup.