### PR TITLE
Feature: Discharge during daytime

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -92,6 +92,7 @@ zero_offset = 20
 [control]
 min_charge_power = 125
 max_discharge_power = 150
-max_inverter_limit = 800                                                
+max_inverter_limit = 800
 limit_inverter = true
 inverter_min_limit = 10
+discharge_during_daytime = false

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -89,6 +89,10 @@ limit_inverter =        config.getboolean('control', 'limit_inverter', fallback=
 steering_interval =     config.getint('control', 'steering_interval', fallback=None) \
                         or int(os.environ.get('STEERING_INTERVAL',15))
 
+# flag, which can be set to allow discharging the battery during daytime
+DISCHARGE_DURING_DAYTIME =     config.getboolean('control', 'discharge_during_daytime', fallback=None) \
+                        or bool(os.environ.get('DISCHARGE_DURING_DAYTIME',False))
+
 #Adjustments possible to sunrise and sunset offset
 SUNRISE_OFFSET =    config.getint('global', 'sunrise_offset', fallback=60) \
                         or int(os.environ.get('SUNRISE_OFFSET',60))                                               
@@ -229,8 +233,8 @@ def getSFPowerLimit(hub, demand) -> int:
                 limit = min(demand,hub_solarpower - MIN_CHARGE_POWER)
         if hub_solarpower - demand <= MIN_CHARGE_POWER:  
             path += "2."
-            if (now < (sunrise + sunrise_off) or now > sunset - sunset_off): 
-                path += "1."                
+            if ((now < (sunrise + sunrise_off) or now > sunset - sunset_off) or DISCHARGE_DURING_DAYTIME): 
+                path += "1."
                 limit = min(demand,MAX_DISCHARGE_POWER)
             else:
                 path += "2."  
@@ -503,6 +507,7 @@ def main(argv):
     log.info(f'  MAX_INVERTER_INPUT = {MAX_INVERTER_INPUT}')
     log.info(f'  SUNRISE_OFFSET = {SUNRISE_OFFSET}')
     log.info(f'  SUNSET_OFFSET = {SUNSET_OFFSET}')
+    log.info(f'  DISCHARGE_DURING_DAYTIME = {DISCHARGE_DURING_DAYTIME}')
 
     loc = MyLocation()
     if not LNG and not LAT:


### PR DESCRIPTION
Hi Reinhard,

first off huge thanks for this project! I installed my Zendure Hub 2000 with an AB2000 battery on saturday and have no complaints so far.
One thing I noticed yesterday was that the hub will not allow a discharge during daytime, causing the consumption from the grid to rise, while the battery has quite a lot of charge (e.g. when a cloud passes and solar power drops).
I implemented an additional flag to override the daytime check at [solarflow-control.py#L239](https://github.com/canbaytok/solarflow-control/blob/c64ad2349f3b86c7d17d88fadb9d1e133b078dc4/src/solarflow/solarflow-control.py#L239) as my nightly need for electricity is quite low and the battery does not need to be fully charged before the sun goes down.

Is this something you would be willing to merge into the main project? I also thought about adding a threshold value to the configuration, where the user can define the battery charge level after which a discharge during daytime is allowed (maybe even a hysteresis with configurations `allow_discharge_during_daytime_after = X%` and `disallow_discharge_during_daytime_after = X%`).

I would also add the necessary documentation to the README.md, before the branch merges (in case a small description is needed)

BR
Can