### PR TITLE
Tune HA Templates

### DIFF
--- a/src/solarflow/homeassistant/number.maxDischargePower.json
+++ b/src/solarflow/homeassistant/number.maxDischargePower.json
@@ -1,5 +1,5 @@
 {
-    "name": "Maximum Disharge Power",
+    "name": "Maximum Discharge Power",
     "cmd_t": "~control/maxDischargePower",
     "stat_t": "~control/maxDischargePower",
     "uniq_id": "{{ device_id }}-maxDischargePower",

--- a/src/solarflow/homeassistant/number.maxDischargePower.json
+++ b/src/solarflow/homeassistant/number.maxDischargePower.json
@@ -4,7 +4,7 @@
     "stat_t": "~control/maxDischargePower",
     "uniq_id": "{{ device_id }}-maxDischargePower",
     "unit_of_meas": "W",
-    "max": 1000,
+    "max": 1200,
     "min": 0,
     "step": 1,
     "mode": "box",

--- a/src/solarflow/homeassistant/number.outputLimit.json
+++ b/src/solarflow/homeassistant/number.outputLimit.json
@@ -6,7 +6,7 @@
     "uniq_id": "{{ device_id }}-outputLimit",
     "dev_cla": "power",
     "unit_of_meas": "W",
-    "max": 800,
+    "max": 1200,
     "min": 0,
     "step": 1,
     "dev": {

--- a/src/solarflow/homeassistant/sensor.maxTemp.json
+++ b/src/solarflow/homeassistant/sensor.maxTemp.json
@@ -1,5 +1,5 @@
 {
-    "name": "Battery Max Temp",
+    "name": "Battery {{battery_index}} Temperature",
     "stat_t": "~maxTemp", 
     "value_template": "{% raw %}{{ (value | float/10 - 273.15) | round(1) }}{% endraw %}",
     "uniq_id": "{{ device_id }}-{{ battery_serial }}-maxTemp",

--- a/src/solarflow/homeassistant/sensor.remainOutTime.json
+++ b/src/solarflow/homeassistant/sensor.remainOutTime.json
@@ -1,0 +1,16 @@
+{
+    "name": "Remaining Discharging Time",
+    "stat_t": "~remainOutTime",
+    "uniq_id": "{{ device_id }}-remainOutTime",
+    "dev_cla": "duration",
+    "unit_of_meas": "min",
+    "value_template": "{% raw %}{{ '0' if value=='59940' else value }}{% endraw %}",
+    "dev": {
+      "identifiers": ["{{ device_id }}"],
+      "manufacturer": "Zendure",
+      "model": "Solarflow",
+      "name": "Solarflow Hub",
+      "sw_version": "{{ fw_version }}"
+    },
+    "~": "solarflow-hub/{{ device_id }}/telemetry/"
+}

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -126,8 +126,8 @@ class Solarflow:
             cfg_type = hatemplate.name.split(".")[0]
             cfg_name = hatemplate.name.split(".")[1]
             if cfg_name == "maxTemp":
-                for serial,v in self.batteriesVol.items():
-                    hacfg = template.render(product_id=self.productId, device_id=self.deviceId, fw_version=self.fwVersion, battery_serial=serial)
+                for index, (serial,v) in enumerate(self.batteriesVol.items()):
+                    hacfg = template.render(product_id=self.productId, device_id=self.deviceId, fw_version=self.fwVersion, battery_serial=serial, battery_index=index+1)
                     if serial != "none":
                         self.client.publish(f'homeassistant/{cfg_type}/solarflow-hub-{self.deviceId}-{serial}-{cfg_name}/config',hacfg,retain=True)
             else:


### PR DESCRIPTION
- Add template for remaining discharge time
- Fix typo in maxDischargePower
- Update max values for Output/Discharge Limits to 1200W which is the maximum value the hub might report. In case the hub reports values that are above the max value from the template, HA will throw an error in the log.