### PR TITLE
Configurable SoC Levels with CT Mode

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '38 22 * * *'
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
 branch=`git rev-parse --abbrev-ref HEAD`
 docker build -t rbrandstaedter/solarflow-control:$branch .
 
-#docker image push rbrandstaedter/solarflow-control:$branch
+docker image push rbrandstaedter/solarflow-control:$branch

--- a/src/config.ini
+++ b/src/config.ini
@@ -91,9 +91,18 @@ zero_offset = 20
 [control]
 min_charge_power = 125
 max_discharge_power = 150
+
+# the maximum power your inverter will feed to home
 max_inverter_limit = 800
+
+# the maximum power the hub would feed to the inverter channel, check with your inverter manual to avoid damage!
+max_inverter_input = 700
+
 limit_inverter = true
+
+# to avoid DTUs to turn completely off and get unresponsive keep a minimum power feed to inverter
 inverter_min_limit = 10
+
 discharge_during_daytime = false
 sunrise_offset = 60
 sunset_offset = 60

--- a/src/solarflow/homeassistant/sensor.totalVol.json
+++ b/src/solarflow/homeassistant/sensor.totalVol.json
@@ -1,0 +1,16 @@
+{
+    "name": "Battery {{battery_index}} Voltage",
+    "stat_t": "~totalVol", 
+    "value_template": "{% raw %}{{ (value | float/100 ) | round(1) }}{% endraw %}",
+    "uniq_id": "{{ device_id }}-{{ battery_serial }}-totalVol",
+    "unit_of_meas": "V",
+    "dev_cla": "voltage",
+    "dev": {
+      "identifiers": ["{{ device_id }}"],
+      "manufacturer": "Zendure",
+      "model": "Solarflow",
+      "name": "Solarflow Hub",
+      "sw_version": "{{ fw_version }}"
+    },
+    "~": "solarflow-hub/{{ device_id }}/telemetry/batteries/{{ battery_serial }}/"
+}

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -186,6 +186,8 @@ def on_connect(client, userdata, flags, rc):
         hub.setInverseMaxPower(MAX_INVERTER_INPUT)
         hub.setBatteryHighSoC(BATTERY_HIGH)
         hub.setBatteryLowSoC(BATTERY_LOW)
+        hub.setACMode()
+        
         if hub.control_bypass:
             hub.setBypass(False)
             hub.setAutorecover(False)

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -278,7 +278,7 @@ def getSFPowerLimit(hub, demand) -> int:
                 path += "1."
                 # FEAT: we should not allow discharging in the sunrise window if battery is still below a certain threshold
                 # e.g. if the battery has just started charging do not discharge it again immediately
-                if (now < (sunrise + sunrise_off)) and hub_electricLevel <= BATTERY_DISCHARGE_START and hub.batteryTarget != solarflow.BATTERY_TARGET_DISCHARGING:
+                if (sunrise < now < (sunrise + sunrise_off)) and hub_electricLevel <= BATTERY_DISCHARGE_START and hub.batteryTarget != solarflow.BATTERY_TARGET_DISCHARGING:
                     path += "1."
                     limit = 0
                 else:

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -519,11 +519,11 @@ def run():
     client.user_data_set({"hub":hub, "dtu":dtu, "smartmeter":smt})
     client.on_message = on_message
 
-    updateConfigParams(client)
     infotimer = RepeatedTimer(120, deviceInfo, client)
 
     #client.loop_start()
     client.loop_forever()
+    updateConfigParams(client)
 
 def main(argv):
     global mqtt_host, mqtt_port, mqtt_user, mqtt_pwd

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -475,7 +475,7 @@ def deviceInfo(client:mqtt_client):
     limitHomeInput(client)
 
 def updateConfigParams(client):
-    global config, DISCHARGE_DURING_DAYTIME, SUNRISE_OFFSET, SUNSET_OFFSET
+    global config, DISCHARGE_DURING_DAYTIME, SUNRISE_OFFSET, SUNSET_OFFSET, MIN_CHARGE_POWER, MAX_DISCHARGE_POWER
 
     # only update if configparameters haven't been updated/read from MQTT
     if DISCHARGE_DURING_DAYTIME == None:

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -144,7 +144,7 @@ class Solarflow:
             template = environment.get_template(hatemplate.name)
             cfg_type = hatemplate.name.split(".")[0]
             cfg_name = hatemplate.name.split(".")[1]
-            if cfg_name == "maxTemp":
+            if cfg_name == "maxTemp" or cfg_name == "totalVol":
                 for index, (serial,v) in enumerate(self.batteriesVol.items()):
                     hacfg = template.render(product_id=self.productId, device_id=self.deviceId, fw_version=self.fwVersion, battery_serial=serial, battery_index=index+1)
                     if serial != "none":

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -79,8 +79,7 @@ class Solarflow:
         self.lastLimitTS = None
 
         client.publish(f'solarflow-hub/{self.deviceId}/control/controlBypass',str(self.control_bypass),retain=True)
-        client.publish(f'solarflow-hub/{self.deviceId}/control/fullChargeInterval',self.full_charge_interval,retain=True)
-
+        client.publish(f'solarflow-hub/{self.deviceId}/control/fullChargeInterval',self.fullChargeInterval,retain=True)
 
         updater = RepeatedTimer(60, self.update)
         haconfig = RepeatedTimer(600, self.pushHomeassistantConfig)

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -466,10 +466,13 @@ class Solarflow:
         # If battery SoC reaches 0% during night, it has been observed that in the morning with first light, residual energy in the batteries gets released
         # Hub goes then into error and no charging occurs (probably deep discharge assumed by the battery).
         # Hence setting the output limit 0 if SoC 0%
-        if self.electricLevel <= self.batteryLow:
+        if self.electricLevel <= self.batteryLow and (not self.chargeThrough and self.chargeThroughStage == BATTERY_TARGET_DISCHARGING):
             limit = 0
-            log.info(f'Battery is empty ({self.electricLevel} <= {self.batteryLow})! Disabling solarflow output, setting limit to {limit}')
+            log.info(f'Battery is at low limit ({self.electricLevel} <= {self.batteryLow}) and charge throug is off. Stop discharging, setting limit to {limit}')
 
+        if self.electricLevel == 0:
+            limit = 0
+            log.info(f'Battery is empty! Disabling solarflow output, setting limit to {limit}')
 
         # Charge-Through:
         # If charge-through is enabled the hub will not provide any power if the last full state is to long ago

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -432,7 +432,7 @@ class Solarflow:
                 case "minSoc":
                     self.updMinSoC(int(value))
                 case "socSet":
-                    self.updupdSocSet(int(value))
+                    self.updSocSet(int(value))
                 case "totalVol":
                     sn = msg.topic.split('/')[-2]
                     self.updBatteryVol(sn=sn, value=int(value))

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -87,13 +87,13 @@ class Solarflow:
         batteries_vol = "|".join([f'{v:2.1f}' for v in self.batteriesVol.values()])
         return ' '.join(f'{red}HUB: \
                         S:{self.solarInputPower:>3.1f}W {self.solarInputValues}, \
-                        B:{self.electricLevel:>3}% ({batteries_soc}), \
+                        B:{self.electricLevel:>3}% ({batteries_soc}) low: {self.batteryLow} high: {self.batteryHigh}, \
                         V:{(sum(self.batteriesVol.values()) / len(self.batteriesVol)):2.1f}V ({batteries_vol}), \
                         C:{self.outputPackPower-self.packInputPower:>4}W, \
                         P:{self.getBypass()} ({"auto" if self.bypass_mode == 0 else "manual"}, {"possible" if self.allow_bypass else "not possible"}), \
                         F:{self.getLastFullBattery():3.1f}h, \
                         E:{self.getLastEmptyBattery():3.1f}h, \
-                        CT:{"ON" if self.chargeThrough else "OFF"} ({self.fullChargeInterval}hrs), \
+                        CT:{"ON" if self.chargeThrough else "OFF"} ({self.fullChargeInterval}hrs) {self.chargeThroughStage}, \
                         H:{self.outputHomePower:>3}W, \
                         L:{self.outputLimit:>3}W{reset}'.split())
 

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -78,6 +78,10 @@ class Solarflow:
 
         self.lastLimitTS = None
 
+        client.publish(f'solarflow-hub/{self.deviceId}/control/controlBypass',str(self.control_bypass),retain=True)
+        client.publish(f'solarflow-hub/{self.deviceId}/control/fullChargeInterval',self.full_charge_interval,retain=True)
+
+
         updater = RepeatedTimer(60, self.update)
         haconfig = RepeatedTimer(600, self.pushHomeassistantConfig)
         self.pushHomeassistantConfig()
@@ -283,6 +287,9 @@ class Solarflow:
             value = 1
         
         self.bypass_mode = value
+    
+    def updFullChargeInterval(self, value: int):
+        self.fullChargeInterval = value
 
     def allowBypass(self, allow):
         self.allow_bypass = allow
@@ -429,6 +436,8 @@ class Solarflow:
                     self.setChargeThrough(value)
                 case "controlBypass":
                     self.setControlBypass(value)
+                case "fullChargeInterval":
+                    self.updFullChargeInterval(int(value))
                 case "dryRun":
                     self.setDryRun(value)
                 case "lastFullTimestamp":

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -263,6 +263,12 @@ class Solarflow:
         self.batteriesSoC.pop("none",None)
         self.batteriesSoC.update({sn:value})
 
+    def updMinSoC(self,value:int):
+        self.batteryLow=int(value/10)
+
+    def updSocSet(self,value:int):
+        self.batteryHigh=int(value/10)
+
     def updBatteryVol(self, sn:str, value:int):
         self.batteriesVol.pop("none",None)
         self.batteriesVol.update({sn:value/100})
@@ -272,9 +278,6 @@ class Solarflow:
         minor = (value & 0x0f00) >> 8
         build = (value & 0x00ff)
         self.fwVersion = f'{major}.{minor}.{build}'
-
-        # put into own timer in init
-        # self.pushHomeassistantConfig() # why here? this is not needed every minute
 
     def updByPass(self, value:int):
         self.bypass = bool(value)
@@ -426,6 +429,10 @@ class Solarflow:
                 case "socLevel":
                     sn = msg.topic.split('/')[-2]
                     self.updBatterySoC(sn=sn, value=int(value))
+                case "minSoc":
+                    self.updMinSoC(int(value))
+                case "socSet":
+                    self.updupdSocSet(int(value))
                 case "totalVol":
                     sn = msg.topic.split('/')[-2]
                     self.updBatteryVol(sn=sn, value=int(value))

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -293,7 +293,7 @@ class Solarflow:
         # **OR** 
         # if SoC levels configured in battery are correct
         log.info(f'Received charge-through control: {value}, Control SoC: {self.control_soc}, SocMax: {self.batteryTargetSoCMax}%, SocMin: {self.batteryTargetSoCMin}%')
-        if chargeThrough and self.control_soc:
+        if chargeThrough and not self.chargeThrough and self.control_soc:
             # if no levels have not been read, wait for then and redo evaluation
             if self.batteryTargetSoCMax < 0 or self.batteryTargetSoCMin < 0:
                 log.info(f'We can control SoC levels but the SoC boundaries read from hub are not available yet. Waiting for update to re-check conditions')

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -93,6 +93,7 @@ class Solarflow:
                         P:{self.getBypass()} ({"auto" if self.bypass_mode == 0 else "manual"}, {"possible" if self.allow_bypass else "not possible"}), \
                         F:{self.getLastFullBattery():3.1f}h, \
                         E:{self.getLastEmptyBattery():3.1f}h, \
+                        CT:{self.fullChargeInterval:>3}h \
                         H:{self.outputHomePower:>3}W, \
                         L:{self.outputLimit:>3}W{reset}'.split())
 
@@ -289,7 +290,7 @@ class Solarflow:
         # chargeThrough can only be used if control_soc is enabled via configuration 
         # **OR** 
         # if SoC levels configured in battery are correct
-        if chargeThrough and not self.control_soc:
+        if chargeThrough and self.control_soc:
             # if no levels have not been read, wait for then and redo evaluation
             if self.batteryTargetSoCMax < 0 or self.batteryTargetSoCMin < 0:
                 log.info(f'We are not allowed to control SoC levels and the values read from battery are not available, yet. Waiting for update to re-check conditions')

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -290,6 +290,7 @@ class Solarflow:
         # chargeThrough can only be used if control_soc is enabled via configuration 
         # **OR** 
         # if SoC levels configured in battery are correct
+        log.info(f'Received charge-through control: {value}, Control SoC: {self.control_soc}, SocMax: {self.batteryTargetSoCMax}, SocMin: {self.batteryTargetSoCMin}')
         if chargeThrough and self.control_soc:
             # if no levels have not been read, wait for then and redo evaluation
             if self.batteryTargetSoCMax < 0 or self.batteryTargetSoCMin < 0:


### PR DESCRIPTION
This release introduces a few improvements and new features:
- Charge Through mode now works with otherwise configureable minimum and max SoC levels. You can now have a lower bound and upper bound (minSoc/socSet) for normal operation where sf-control will consider the battery empty or full. Only when CT mode is enabled they will dynamically change to 0% and 100% to allow a full cycle for calibration (#294)
- introduce a minimum battery charge level that has to be reached before the battery is discharged in the morning (during the sunrise window)
- add homeassistant template for individual battery voltage (#304)
- enforce acMode (which has been introduced with a recent firmware update) when accidentally set incorrect in the mobile app (#307)
-  prefer MQTT settings when present in broker over config settings from ini file - this also allows to dynamically set some config settings without the need of a restart (#308)