### PR TITLE
Extend smartmeter by Shelly 3EM Pro (FW > 1.0.7)

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -1,7 +1,7 @@
 [global]
 # DTY Type: either OpenDTU or AhoyDTU
 dtu_type = OpenDTU
-# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3
+# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3, ShellyEM3Pro
 smartmeter_type = Smartmeter
 
 # Geolocation LAT/LNG
@@ -82,9 +82,18 @@ zero_offset = 20
 
 
 [shellyem3]
-# The MQTT base topic your Shelly 3EM (Pro) is posting it's telemetry data to
+# The MQTT base topic your Shelly 3EM is posting it's telemetry data to
 # Note: you have to configure your Shelly to use MQTT
 base_topic = shellies/shellyem3/
+rapid_change_diff = 500
+zero_offset = 20
+
+[shellyem3pro]
+# The MQTT base topic your Shelly 3EM (Pro) [FW > 1.0.7] is posting it's telemetry data to
+# Note: you have to configure your Shelly to use MQTT
+
+# Base topic is defined as {MQTT_Prefix}/status/em:{ID}
+base_topic = shellies/shellyem3/status/em:0
 rapid_change_diff = 500
 zero_offset = 20
 


### PR DESCRIPTION
Added:
* Class `Shelly3EMPro` in file `smartmeters.py` for reading mqtt topics provided by Shelly 3EM Pro
  * Topic follows pattern `{MQTT Prefix}/status/em:{ID}/[abc]_act_power`
  * Tested with FW > 1.0.7
* Configuration section `shelly3empro` in file `config.ini`