### PR TITLE
Feat/refactor config setting reads

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
 branch=`git rev-parse --abbrev-ref HEAD`
-docker build -t rbrandstaedter/solarflow-control:$branch .
+docker build -t rbrandstaedter/solarflow-control:local .
 
-docker image push rbrandstaedter/solarflow-control:$branch
+docker image push rbrandstaedter/solarflow-control:local

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -548,8 +548,8 @@ def run():
     subscribe(client=client)
 
     log.info("Reading retained config settings from MQTT...")
-    log.info("Note: Solarflow Control persists initial configuration settings in your MQTT broker and will use those first (if found) to allow on-the-fly updates! \
-             If you want to override these values from your config.ini you need to clear those retained topics in your broker first!")
+    log.info("Note: Solarflow Control persists initial configuration settings in your MQTT broker and will use those first (if found) to allow on-the-fly updates!")
+    log.info("If you want to override these values from your config.ini you need to clear those retained topics in your broker first!")
     client.loop_start()
     time.sleep(10)
   

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -548,6 +548,8 @@ def run():
     subscribe(client=client)
 
     log.info("Waiting for config settings retained in MQTT...")
+    log.info("Note: Solarflow Control persists initial configuration settings in your MQTT broker and will use those first (if found) to allow on-the-fly updates! \
+             If you want to override these values from your config.ini you need to clear those retained topics in your broker first!")
     client.loop_start()
     time.sleep(10)
     log.info("...done")

--- a/src/solarflow/solarflow-control.py
+++ b/src/solarflow/solarflow-control.py
@@ -547,12 +547,12 @@ def run():
     client = connect_mqtt()
     subscribe(client=client)
 
-    log.info("Waiting for config settings retained in MQTT...")
+    log.info("Reading retained config settings from MQTT...")
     log.info("Note: Solarflow Control persists initial configuration settings in your MQTT broker and will use those first (if found) to allow on-the-fly updates! \
              If you want to override these values from your config.ini you need to clear those retained topics in your broker first!")
     client.loop_start()
     time.sleep(10)
-    log.info("...done")
+  
     # if no config setting were found in MQTT (retained) then update config from config file
     updateConfigParams(client)
 

--- a/src/solarflow/solarflow.py
+++ b/src/solarflow/solarflow.py
@@ -431,12 +431,8 @@ class Solarflow:
                     self.updBatterySoC(sn=sn, value=int(value))
                 case "minSoc":
                     self.updMinSoC(int(value))
-                case "batteryTargetSoCMin":
-                    self.updBatteryTargetSoCMin(int(value))
                 case "socSet":
                     self.updSocSet(int(value))
-                case "batteryTargetSoCMax":
-                    self.updBatteryTargetSoCMax(int(value))
                 case "totalVol":
                     sn = msg.topic.split('/')[-2]
                     self.updBatteryVol(sn=sn, value=int(value))
@@ -444,10 +440,6 @@ class Solarflow:
                     self.updMasterSoftVersion(value=int(value))
                 case "chargeThrough":
                     self.setChargeThrough(value)
-                case "controlBypass":
-                    self.setControlBypass(value)
-                case "fullChargeInterval":
-                    self.updFullChargeInterval(int(value))
                 case "dryRun":
                     self.setDryRun(value)
                 case "lastFullTimestamp":


### PR DESCRIPTION
This should address #323 and #324

sf-control will now read mandatory config settings from config.ini, then try to read retained config settings from MQTT and if not found read those from the config file. This allows dynamic change of certain config settings via MQTT.