### PR TITLE
Add ShellyPro3EM

### DIFF
--- a/examples/local_mqtt_with_control/config.ini
+++ b/examples/local_mqtt_with_control/config.ini
@@ -1,7 +1,7 @@
 [global]
 # DTY Type: either OpenDTU or AhoyDTU
 dtu_type = OpenDTU
-# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3
+# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3, ShellyPro3EM
 smartmeter_type = Smartmeter
 
 # Geolocation LAT/LNG
@@ -71,6 +71,11 @@ poweropti_password = <Powerfox API password>
 # The MQTT base topic your Shelly 3EM (Pro) is posting it's telemetry data to
 # Note: you have to configure your Shelly to use MQTT
 base_topic = shellies/shellyem3/
+
+[shellypro3em]
+# Note, the base topic needs 
+base_topic = shellypro3em 
+cur_accessor = total_act_power
 
 [control]
 min_charge_power = 125

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,7 +1,7 @@
 [global]
 # DTY Type: either OpenDTU or AhoyDTU
 dtu_type = OpenDTU
-# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3
+# Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3, ShellyPro3EM
 smartmeter_type = Smartmeter
 
 # Geolocation LAT/LNG
@@ -14,7 +14,7 @@ smartmeter_type = Smartmeter
 # Hub-2000: "A8yh63"
 # Hyper 2000: "gDa3tb"
 # defaults to 73bkTV
-#product_id = 73bkTV
+# product_id = 73bkTV
 # The device ID of your Solarflow Hub (typically 8 characters), you can get these either with solarflow-bt-manager or the solarflow-statuspage
 device_id = 5ak8yGU7
 
@@ -85,9 +85,17 @@ zero_offset = 20
 
 
 [shellyem3]
-# The MQTT base topic your Shelly 3EM (Pro) is posting it's telemetry data to
+# The MQTT base topic your Shelly 3EM is posting it's telemetry data to
 # Note: you have to configure your Shelly to use MQTT
 base_topic = shellies/shellyem3/
+rapid_change_diff = 500
+zero_offset = 20
+
+[shellypro3em]
+# The MQTT base topic your ShellyPro3EM is posting it's telemetry data to
+# Note: you have to configure your Shelly to use MQTT
+base_topic = shellypro3em
+cur_accessor = total_act_power
 rapid_change_diff = 500
 zero_offset = 20
 

--- a/src/solarflow/smartmeters.py
+++ b/src/solarflow/smartmeters.py
@@ -176,6 +176,29 @@ class ShellyEM3(Smartmeter):
             self.client.subscribe(t)
             log.info(f'Shelly3EM subscribing: {t}')
 
+class ShellyPro3EM(Smartmeter):
+    opts = {"base_topic":str, "rapid_change_diff":int, "zero_offset": int, "cur_accessor":str}
+
+    def __init__(self, client: mqtt_client, base_topic:str, cur_accessor:str, rapid_change_diff:int = 500, zero_offset:int = 0, callback = Smartmeter.default_calllback):
+        self.client = client
+        self.base_topic = base_topic
+        self.power = TimewindowBuffer(minutes=1)
+        self.phase_values = {}
+        self.rapid_change_diff = rapid_change_diff
+        self.zero_offset = zero_offset
+        self.last_trigger_value = 0
+        self.trigger_callback = callback
+        self.scaling_factor = 1
+        self.cur_accessor = cur_accessor
+
+        log.info(f'Using {type(self).__name__}: Base topic: {self.base_topic}')
+
+    def subscribe(self):
+        topics = [f'{self.base_topic}/status/em:0']
+        for t in topics:
+            self.client.subscribe(t)
+            log.info(f'ShellyPro3EM subscribing: {t}')
+
 class VZLogger(Smartmeter):
     opts = {"cur_usage_topic":str, "rapid_change_diff":int, "zero_offset": int}
 


### PR DESCRIPTION
Adding support for https://www.shelly.com/products/shelly-pro-3em-x1 smartmeter, which publishes to a different MQTT path / format than the ShellyEM3 (prior generation product). 

The MQTT path is `shellypro3em/status/em:0` and within the payload total current power across all phases is available as `total_act_power`. 

`shellypro3em` is the default prefix in Shelly's MQTT config, but is changeable (hence set as base topic). Verified with v1.4.4 on Shelly Pro3EM.

![image](https://github.com/user-attachments/assets/e2b3bd74-4106-44e0-9320-5e3f03621218)
